### PR TITLE
 Add new presets to apply both libtorrent defaults and the more specific settings.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+Version 2.0.1
+- Add new presets to apply both libtorrent defaults and the more specific settings
+
 Version 2.0.0
 - Update to support Deluge 2.x and Python 3
 

--- a/ltconfig/core.py
+++ b/ltconfig/core.py
@@ -79,6 +79,13 @@ DEPRECATED_FLOATS = [
 NETWORK_SERVICES = ["dht", "lsd", "natpmp", "upnp"]
 
 
+def merged_dict(a, b):
+  dict_a = dict(a)
+  dict_b = dict(b)
+  for key, value in dict_b.items():
+    dict_a[key] = value
+  return dict_a
+
 class Core(CorePluginBase):
 
   def __init__(self, plugin_name):
@@ -164,6 +171,10 @@ class Core(CorePluginBase):
       settings = dict(HIGH_PERFORMANCE_SEED)
     elif preset == 3:
       settings = dict(MIN_MEMORY_USAGE)
+    elif preset == 4:
+      settings = merged_dict(LIBTORRENT_DEFAULTS, HIGH_PERFORMANCE_SEED)
+    elif preset == 5:
+      settings = merged_dict(LIBTORRENT_DEFAULTS, MIN_MEMORY_USAGE)
 
     for key in list(settings.keys()):
       # Presets use integer values in place of floats (for >= 1.1.x).

--- a/ltconfig/data/ltconfig.js
+++ b/ltconfig/data/ltconfig.js
@@ -124,7 +124,9 @@ Deluge.plugins.ltconfig.ui.PreferencePage = Ext.extend(Ext.Panel, {
           [0, 'Pre-ltConfig Settings'],
           [1, 'Libtorrent Defaults'],
           [2, 'High Performance Seed'],
-          [3, 'Minimum Memory Usage']
+          [3, 'Minimum Memory Usage'],
+          [4, 'Libtorrent Defaults + High Performance Seed'],
+          [5, 'Libtorrent Defaults + Minimum Memory Usage']
         ],
         value: 0,
         editable: false,

--- a/ltconfig/data/wnd_preferences.glade
+++ b/ltconfig/data/wnd_preferences.glade
@@ -79,7 +79,9 @@
                             <property name="items" translatable="yes">Pre-ltConfig Settings
 Libtorrent Defaults
 High Performance Seed
-Minimum Memory Usage</property>
+Minimum Memory Usage
+Libtorrent Defaults + High Performance Seed
+Libtorrent Defaults + Minimum Memory Usage</property>
                           </widget>
                           <packing>
                             <property name="expand">False</property>

--- a/ltconfig/data/wnd_preferences.ui
+++ b/ltconfig/data/wnd_preferences.ui
@@ -17,6 +17,12 @@
       <row>
         <col id="0" translatable="yes">Minimum Memory Usage</col>
       </row>
+      <row>
+        <col id="0" translatable="yes">Libtorrent Defaults + High Performance Seed</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Libtorrent Defaults + Minimum Memory Usage</col>
+      </row>
     </data>
   </object>
   <!-- interface-requires gtk+ 2.16 -->

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup, find_packages
 __plugin_name__ = "ltConfig"
 __author__ = "Ratanak Lun"
 __author_email__ = "ratanakvlun@gmail.com"
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 __url__ = "http://github.com/ratanakvlun"
 __license__ = "GPLv3"
 __description__ = "Modify libtorrent settings"


### PR DESCRIPTION
This adds the new presets **Libtorrent Defaults + High Performance Seed** & **Libtorrent Defaults + Minimum Memory Usage** to first apply the libtorrent defaults and then override them with the more specific presets.

This makes it easier to apply the high performance / minimum memory preset while also making sure Deluge's config does not divert from the libtorrent defaults.